### PR TITLE
Move moduleName to front of title / tab

### DIFF
--- a/frontend/Page/Module.elm
+++ b/frontend/Page/Module.elm
@@ -19,7 +19,7 @@ port context : { user : String, name : String, version : String, versionList : L
 
 port title : String
 port title =
-    context.user ++ "/" ++ context.name ++ " " ++ context.version ++ " " ++ context.moduleName
+    context.moduleName ++ " " ++ context.user ++ "/" ++ context.name ++ context.version 
 
 
 packageUrl : String -> String


### PR DESCRIPTION
The moduleName was at the end of the title, so often got lost with multiple tabs (see attached image). Putting moduleName at the front solves this.
![image](https://cloud.githubusercontent.com/assets/8269863/9840629/cf8cb372-5a5a-11e5-8ce5-b187e180e438.png)
